### PR TITLE
Pass in `now` as a callable rather than a value

### DIFF
--- a/magazines/models.py
+++ b/magazines/models.py
@@ -17,7 +17,7 @@ class Purchase(models.Model):
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='purchases')
     magazine = models.ForeignKey(Magazine)
-    subscription_end = models.DateTimeField(default=timezone.now())
+    subscription_end = models.DateTimeField(default=timezone.now)
 
 
 # To avoid an "apps not loaded" error the import from signals is placed at the bottom of file


### PR DESCRIPTION
This should make the time more accurate, and get rid of the warning